### PR TITLE
Add colors for simple-thermostat buttons

### DIFF
--- a/themes/midnight.yaml
+++ b/themes/midnight.yaml
@@ -61,6 +61,8 @@ midnight:
   slider-bar-color: "var(--disabled-text-color)"
   slider-color: "var(--primary-color)"
   slider-secondary-color: "var(--light-primary-color)"
+  st-mode-active-background: "var(--dark-primary-color)"
+  st-mode-background: "var(--primary-background-color)"
   state-icon-active-color: "#FDD835"
   state-icon-color: "#44739e"
   state-icon-unavailable-color: "var(--disabled-text-color)"


### PR DESCRIPTION
Simple-Thermostat default button colors look like this:

<img width="466" alt="Screen Shot 2020-05-02 at 7 10 29 PM" src="https://user-images.githubusercontent.com/7717888/80895276-a2af1900-8ca8-11ea-8b0d-7692f8e03ae0.png">

After this change, they will look like this:

<img width="465" alt="Screen Shot 2020-05-02 at 7 10 39 PM" src="https://user-images.githubusercontent.com/7717888/80895277-a80c6380-8ca8-11ea-96f9-e70d90c31080.png">
