### PR TITLE
Add dark background to slider tooltip

### DIFF
--- a/themes/midnight.yaml
+++ b/themes/midnight.yaml
@@ -85,3 +85,4 @@ midnight:
   md-slider-label-container-color: "var(--accent-color)"
   md-slider-pressed-state-layer-color: "var(--accent-color)"
   md-slider-inactive-track-color: "var(--secondary-background-color)"
+  clear-background-color: "var(--secondary-background-color)"


### PR DESCRIPTION
This patch fixes #43 
![image](https://github.com/user-attachments/assets/85e58c9b-d683-4167-b105-c90d460cfc8e)
