### PR TITLE
Red Radio buttons, red slider, blue top bar, dark-mode setting

### DIFF
--- a/themes/midnight.yaml
+++ b/themes/midnight.yaml
@@ -4,6 +4,7 @@
 #
 midnight:
   accent-color: "#E45E65"
+  accent-color-alpha: "#E45E6599"
   accent-color-dark: "#93535C"
   card-background-color: "var(--primary-background-color)"
   clear-background-color: "var(--secondary-background-color)"
@@ -84,9 +85,18 @@ midnight:
   md-slider-pressed-state-layer-color: "var(--accent-color)"
   md-slider-inactive-track-color: "var(--secondary-background-color)"
   
+  
+  ## Header
+  app-header-background-color: "var(--primary-color)" #blue tab bar on top
+  app-header-selection-bar-color: "var(--accent-color)" #red line below selected tab
+  # app-header-edit-background-color:
+  # app-header-edit-text-color:
+  # app-header-border-bottom:
+  # app-header-text-color:
+  
   ## Unchecked switch
   ha-switch-background-color: "#5B616B"
-  ha-switch-background-color-hover: "#5B616B"
+  ha-switch-background-color-hover: "#7F848E88"
   ha-switch-border-color: "var(--disabled-text-color)"
   ha-switch-thumb-background-color: "var(--disabled-text-color)"
   ha-switch-thumb-background-color-hover: "var(--disabled-text-color)"
@@ -94,7 +104,7 @@ midnight:
 
   ## Checked switch
   ha-switch-checked-background-color: "var(--accent-color-dark)" 
-  ha-switch-checked-background-color-hover: "var(--accent-color-dark)"
+  ha-switch-checked-background-color-hover: "var(--accent-color-alpha)"
   ha-switch-checked-border-color: "var(--accent-color)"
   ha-switch-checked-border-color-hover: "var(--accent-color)"
   ha-switch-checked-thumb-background-color: "var(--accent-color)"
@@ -141,6 +151,11 @@ midnight:
   # ha-radio-option-checked-icon-scale
   # ha-radio-option-control-margin
   # ha-radio-option-heigh
+  
+  ## Slider
+  ha-slider-thumb-color: "var(--accent-color)"
+  ha-slider-indicator-color: "var(--accent-color)"
+  # ha-slider-track-size: "4px"
 
   ## Tooltips, and others
   ha-color-surface-default: "var(--paper-listbox-background-color)"
@@ -149,6 +164,8 @@ midnight:
 # ha-color-surface-default-inverted
 # ha-color-surface-low-inverted
 # ha-color-surface-lower-inverted
+
+  wa-color-surface-raised: "var(--accent-color)" #Top line in notifications panel
 
 
   ## Labels, forms, lists, buttons, etc.

--- a/themes/midnight.yaml
+++ b/themes/midnight.yaml
@@ -126,6 +126,22 @@ midnight:
 # ha-checkbox-required-marker
 # ha-checkbox-required-marker-offset
 
+  ## Radio button
+  ha-radio-option-active-color: "var(--accent-color)"
+  ha-radio-option-border-color: "var(--disabled-text-color)"
+  ha-radio-option-border-color-hover: "var(--accent-color)"
+  ha-radio-option-background-color: "var(--primary-background-color)"
+  ha-radio-option-background-color-hover: "var(--primary-background-color)"
+  ha-radio-option-checked-background-color: "var(--primary-background-color)"
+  ha-radio-option-checked-icon-color: "var(--accent-color)"
+  # ha-radio-group-required-marker
+  # ha-radio-group-required-marker-offset
+  # ha-radio-option-toggle-size
+  # ha-radio-option-border-width  
+  # ha-radio-option-checked-icon-scale
+  # ha-radio-option-control-margin
+  # ha-radio-option-heigh
+
   ## Tooltips, and others
   ha-color-surface-default: "var(--paper-listbox-background-color)"
 # ha-color-surface-low

--- a/themes/midnight.yaml
+++ b/themes/midnight.yaml
@@ -114,8 +114,8 @@ midnight:
   ## Checkbox
   ha-checkbox-border-color: "var(--disabled-text-color)"
   ha-checkbox-border-color-hover: "var(--accent-color)"
-  ha-checkbox-background-color: "var(--primary-background-color)"
-  ha-checkbox-background-color-hover: "var(--primary-background-color)"
+  ha-checkbox-background-color: "#11111100"
+  ha-checkbox-background-color-hover: "#11111100"
   ha-checkbox-checked-background-color: "var(--accent-color)"
   ha-checkbox-checked-background-color-hover: "var(--accent-color-dark)"
   ha-checkbox-checked-icon-color: "var(--primary-text-color)"
@@ -130,8 +130,8 @@ midnight:
   ha-radio-option-active-color: "var(--accent-color)"
   ha-radio-option-border-color: "var(--disabled-text-color)"
   ha-radio-option-border-color-hover: "var(--accent-color)"
-  ha-radio-option-background-color: "var(--primary-background-color)"
-  ha-radio-option-background-color-hover: "var(--primary-background-color)"
+  ha-radio-option-background-color: "#11111100"
+  ha-radio-option-background-color-hover: "#11111100"
   ha-radio-option-checked-background-color: "var(--primary-background-color)"
   ha-radio-option-checked-icon-color: "var(--accent-color)"
   # ha-radio-group-required-marker

--- a/themes/midnight.yaml
+++ b/themes/midnight.yaml
@@ -195,3 +195,6 @@ midnight:
   ha-color-fill-neutral-normal-resting: "var(--form-hover)"
   ha-color-fill-neutral-normal-hover: "var(--accent-color-dark)"
   ha-color-fill-neutral-normal-active: "var(--accent-color)"
+
+  modes:
+    dark: {}


### PR DESCRIPTION
Added a few tweaks.

Added red radio buttons from the latest 2026.6 release
<img width="474" height="123" alt="image" src="https://github.com/user-attachments/assets/9c409bcf-cb81-4a1c-8a82-2d513c67b574" />


Added red sliders
<img width="209" height="52" alt="image" src="https://github.com/user-attachments/assets/dddaf4ad-b2e5-4e46-a532-4f41e7bf03b4" />


Brought back the blue top bar, and added a red accent bar underneath
<img width="216" height="93" alt="image" src="https://github.com/user-attachments/assets/b2c6ecf4-c700-43cc-8d26-c51ec86aed54" />


Added dark-mode as the theme default setting to get a better match with a few default colors.
Example:
new:
<img width="113" height="68" alt="image" src="https://github.com/user-attachments/assets/7e50ff39-92cf-4d04-92be-155ca561f511" />
hover
<img width="161" height="94" alt="image" src="https://github.com/user-attachments/assets/ea612c95-9cfa-49f2-a928-2d2ac8592b44" />

 old:
 <img width="109" height="72" alt="image" src="https://github.com/user-attachments/assets/53a574a6-0639-493d-9615-606579cb952d" />
 hover
<img width="180" height="118" alt="image" src="https://github.com/user-attachments/assets/62c979bf-32dd-4e49-8bc4-f01ad9409645" />

 